### PR TITLE
Support `FetchOptions` (#33)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,15 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 wasm-streams = "0.3.0"
 web-sys = { version = "0.3.61", features = [
+    "AbortSignal",
     "Headers",
+    "ReadableStream",
+    "ReferrerPolicy",
     "Request",
+    "RequestCache",
+    "RequestCredentials",
+    "RequestInit",
+    "RequestRedirect",
     "Response",
     "ServiceWorkerGlobalScope",
-    "RequestInit",
-    "RequestCredentials",
-    "ReadableStream",
 ] }

--- a/src/call.rs
+++ b/src/call.rs
@@ -7,7 +7,10 @@ use http_body::Body;
 use js_sys::{Array, Uint8Array};
 use tonic::body::BoxBody;
 use wasm_bindgen::JsValue;
-use web_sys::{AbortSignal, Headers, ReferrerPolicy, RequestCredentials, RequestCache, RequestRedirect, RequestInit};
+use web_sys::{
+    AbortSignal, Headers, ReferrerPolicy, RequestCache, RequestCredentials, RequestInit,
+    RequestRedirect,
+};
 
 use crate::{fetch::fetch, Error, ResponseBody};
 
@@ -24,7 +27,7 @@ pub struct FetchOptions {
     /// The HTTP method to use for the request. The default is POST.
     pub method: String,
 
-    /// Indicates how the request will use the browser's HTTP cache. The default is "default". 
+    /// Indicates how the request will use the browser's HTTP cache. The default is "default".
     pub cache: RequestCache,
 
     /// Sets how redirects are handled. The default is "follow".
@@ -35,7 +38,7 @@ pub struct FetchOptions {
 
     /// The referrer policy of the request. If None, does not override the default referrer policy.
     pub referrer_policy: Option<ReferrerPolicy>,
-    
+
     /// The integrity value of the request (i.e.: a hash of the body). If None, is not set.
     pub integrity: Option<String>,
 
@@ -60,7 +63,6 @@ impl Default for FetchOptions {
     }
 }
 
-
 pub async fn call(
     mut base_url: String,
     request: Request<BoxBody>,
@@ -75,9 +77,13 @@ pub async fn call(
             let exists = headers.has(header_name.as_str()).map_err(Error::js_error)?;
 
             if exists {
-                headers.set(header_name.as_str(), header_value.to_str()?).map_err(Error::js_error)?;
+                headers
+                    .set(header_name.as_str(), header_value.to_str()?)
+                    .map_err(Error::js_error)?;
             } else {
-                headers.append(header_name.as_str(), header_value.to_str()?).map_err(Error::js_error)?;
+                headers
+                    .append(header_name.as_str(), header_value.to_str()?)
+                    .map_err(Error::js_error)?;
             }
         }
     }

--- a/src/call.rs
+++ b/src/call.rs
@@ -12,6 +12,7 @@ use web_sys::{AbortSignal, Headers, ReferrerPolicy, RequestCredentials, RequestC
 use crate::{fetch::fetch, Error, ResponseBody};
 
 /// Override the default options for the fetch Web API call. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) for details.
+#[derive(Debug, Clone)]
 pub struct FetchOptions {
     /// Controls what browsers do with credentials (cookies, HTTP authentication entries, and TLS client certificates)
     /// omit, same-origin, or include. The default is same-origin when FetchOptions is not specified.
@@ -63,11 +64,9 @@ impl Default for FetchOptions {
 pub async fn call(
     mut base_url: String,
     request: Request<BoxBody>,
-    options: Option<FetchOptions>,
+    options: FetchOptions,
 ) -> Result<Response<ResponseBody>, Error> {
     base_url.push_str(&request.uri().to_string());
-
-    let options = options.unwrap_or_default();
 
     let headers = prepare_headers(request.headers())?;
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -7,9 +7,58 @@ use http_body::Body;
 use js_sys::{Array, Uint8Array};
 use tonic::body::BoxBody;
 use wasm_bindgen::JsValue;
-use web_sys::{Headers, RequestCredentials, RequestInit};
+use web_sys::{AbortSignal, Headers, ReferrerPolicy, RequestCredentials, RequestCache, RequestRedirect, RequestInit};
 
 use crate::{fetch::fetch, Error, ResponseBody};
+
+/// Override the default options for the fetch Web API call. See [MDN](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) for details.
+pub struct FetchOptions {
+    /// Controls what browsers do with credentials (cookies, HTTP authentication entries, and TLS client certificates)
+    /// omit, same-origin, or include. The default is same-origin when FetchOptions is not specified.
+    pub credentials: RequestCredentials,
+
+    /// These headers are applied to the request after set_response_headers() is called, allowing overrides.
+    pub header_override: Option<Headers>,
+
+    /// The HTTP method to use for the request. The default is POST.
+    pub method: String,
+
+    /// Indicates how the request will use the browser's HTTP cache. The default is "default". 
+    pub cache: RequestCache,
+
+    /// Sets how redirects are handled. The default is "follow".
+    pub redirect: RequestRedirect,
+
+    /// The referrer of the request. If None, does not override the default referrer.
+    pub referrer: Option<String>,
+
+    /// The referrer policy of the request. If None, does not override the default referrer policy.
+    pub referrer_policy: Option<ReferrerPolicy>,
+    
+    /// The integrity value of the request (i.e.: a hash of the body). If None, is not set.
+    pub integrity: Option<String>,
+
+    /// The AbortSignal associated with the request. If None, is not set.
+    /// This can be used to abort a long-running request.
+    pub abort_signal: Option<AbortSignal>,
+}
+
+impl Default for FetchOptions {
+    fn default() -> Self {
+        Self {
+            credentials: RequestCredentials::SameOrigin,
+            header_override: None,
+            method: "POST".to_string(),
+            cache: RequestCache::Default,
+            redirect: RequestRedirect::Follow,
+            referrer: None,
+            referrer_policy: None,
+            integrity: None,
+            abort_signal: None,
+        }
+    }
+}
+
 
 pub async fn call(
     mut base_url: String,
@@ -71,7 +120,7 @@ fn prepare_request(
     init.method("POST")
         .headers(headers.as_ref())
         .body(body.as_ref())
-        .credentials(RequestCredentials::SameOrigin);
+        .credentials(RequestCredentials::Include);
 
     web_sys::Request::new_with_str_and_init(url, &init).map_err(Error::js_error)
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,18 +8,24 @@ use http::{Request, Response};
 use tonic::body::BoxBody;
 use tower_service::Service;
 
-use crate::{call::call, Error, ResponseBody};
+use crate::{call::{call, FetchOptions}, Error, ResponseBody};
 
 /// `grpc-web` based transport layer for `tonic` clients
 #[derive(Debug, Clone)]
 pub struct Client {
     base_url: String,
+    options: FetchOptions,
 }
 
 impl Client {
     /// Creates a new client
     pub fn new(base_url: String) -> Self {
-        Self { base_url }
+        Self { base_url, options: FetchOptions::default() }
+    }
+
+    /// Creates a new client with custom options
+    pub fn new_with_options(base_url: String, options: FetchOptions) -> Self {
+        Self { base_url, options }
     }
 }
 
@@ -35,6 +41,6 @@ impl Service<Request<BoxBody>> for Client {
     }
 
     fn call(&mut self, request: Request<BoxBody>) -> Self::Future {
-        Box::pin(call(self.base_url.clone(), request, None))
+        Box::pin(call(self.base_url.clone(), request, self.options.clone()))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -35,6 +35,6 @@ impl Service<Request<BoxBody>> for Client {
     }
 
     fn call(&mut self, request: Request<BoxBody>) -> Self::Future {
-        Box::pin(call(self.base_url.clone(), request))
+        Box::pin(call(self.base_url.clone(), request, None))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,10 @@ use http::{Request, Response};
 use tonic::body::BoxBody;
 use tower_service::Service;
 
-use crate::{call::{call, FetchOptions}, Error, ResponseBody};
+use crate::{
+    call::{call, FetchOptions},
+    Error, ResponseBody,
+};
 
 /// `grpc-web` based transport layer for `tonic` clients
 #[derive(Debug, Clone)]
@@ -20,7 +23,10 @@ pub struct Client {
 impl Client {
     /// Creates a new client
     pub fn new(base_url: String) -> Self {
-        Self { base_url, options: FetchOptions::default() }
+        Self {
+            base_url,
+            options: FetchOptions::default(),
+        }
     }
 
     /// Creates a new client with custom options

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ mod error;
 mod fetch;
 mod response_body;
 
-pub use self::{client::Client, error::Error, response_body::ResponseBody};
 pub use self::call::FetchOptions;
+pub use self::{client::Client, error::Error, response_body::ResponseBody};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,3 +47,4 @@ mod fetch;
 mod response_body;
 
 pub use self::{client::Client, error::Error, response_body::ResponseBody};
+pub use self::call::FetchOptions;


### PR DESCRIPTION
As detailed in #33, it would be nice to be able to specify or override the options passed to the Web API fetch() request. 

This PR implements the concept. I have used it successfully to specify `credentials: include` in my own project, and I have also run the simple test suite locally with success.

Here's how I used it in my project:

```rust
use tonic_web_wasm_client::{Client, FetchOptions};
use web_sys::RequestCredentials;

let options = FetchOptions{ credentials: RequestCredentials::Include, ..Default::default()};        
let mut query_client: AuthenticationServiceClient<Client> = AuthenticationServiceClient::new(Client::new_with_options(BASE_URL.to_owned(), options));
```

We could reexport some of these required `web_sys` structs to make things easier for users.

I have not tested any options besides credentials as of this writing.

The default `Client::new` function will create a `FetchOptions` instance with `FetchOptions::default()`. I have implemented a `Default` handling that makes our default settings clear. 