### PR TITLE
Bump tonic to 0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ httparse = "1.8.0"
 js-sys = "0.3.61"
 pin-project = "1.0.12"
 thiserror = "1.0.38"
-tonic = { version = "0.8.3", default-features = false }
+tonic = { version = "0.9.2", default-features = false }
 tower-service = "0.3.2"
 wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"

--- a/test-suite/gzip/client/Cargo.toml
+++ b/test-suite/gzip/client/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 
 [dependencies]
 prost = "0.11.5"
-tonic = { version = "0.8.3", default-features = false, features = [
+tonic = { version = "0.9.2", default-features = false, features = [
     "prost",
     "codegen",
     "gzip",
 ] }
 
 [build-dependencies]
-tonic-build = { version = "0.8.4", default-features = false, features = [
+tonic-build = { version = "0.9.2", default-features = false, features = [
     "prost",
 ] }
 

--- a/test-suite/gzip/server/Cargo.toml
+++ b/test-suite/gzip/server/Cargo.toml
@@ -10,11 +10,11 @@ futures-core = "0.3.25"
 http = "0.2.8"
 prost = "0.11.5"
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
-tonic = { version = "0.8.3", features = ["gzip"] }
-tonic-web = "0.5.0"
+tonic = { version = "0.9.2", features = ["gzip"] }
+tonic-web = "0.9.2"
 tower-http = { version = "0.3.5", default-features = false, features = [
     "cors",
 ] }
 
 [build-dependencies]
-tonic-build = "0.8.4"
+tonic-build = "0.9.2"

--- a/test-suite/simple/client/Cargo.toml
+++ b/test-suite/simple/client/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 prost = "0.11.5"
-tonic = { version = "0.8.3", default-features = false, features = [
+tonic = { version = "0.9.2", default-features = false, features = [
     "prost",
     "codegen",
 ] }
 
 [build-dependencies]
-tonic-build = { version = "0.8.4", default-features = false, features = [
+tonic-build = { version = "0.9.2", default-features = false, features = [
     "prost",
 ] }
 

--- a/test-suite/simple/server/Cargo.toml
+++ b/test-suite/simple/server/Cargo.toml
@@ -10,11 +10,11 @@ futures-core = "0.3.25"
 http = "0.2.8"
 prost = "0.11.5"
 tokio = { version = "1.23.0", features = ["macros", "rt-multi-thread"] }
-tonic = "0.8.3"
-tonic-web = "0.5.0"
+tonic = "0.9.2"
+tonic-web = "0.9.2"
 tower-http = { version = "0.3.5", default-features = false, features = [
     "cors",
 ] }
 
 [build-dependencies]
-tonic-build = "0.8.4"
+tonic-build = "0.9.2"


### PR DESCRIPTION
In the newer version of tonic they [change the status struct](https://github.com/hyperium/tonic/commit/ee3d0dfe7556fc7e996764f650ee3351097e7309), which make code using `tonic-web-wasm-client` breaks if using the newer version of tonic (0.9.x). 
This PR just bumps the tonic version in order to enable users to use the latest version of tonic.
