### PR TITLE
fix: incompatible options and request payloads for fetch

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -21,7 +21,7 @@ pub async fn call(
     let headers = prepare_headers(request.headers())?;
     let body = prepare_body(request).await?;
 
-    let request = prepare_request(&base_url, headers, body)?;
+    let request = prepare_request(&base_url, headers, body, options.clone())?;
     let response = fetch(&request, options).await?;
 
     let result = Response::builder().status(response.status());
@@ -66,6 +66,7 @@ fn prepare_request(
     url: &str,
     headers: Headers,
     body: Option<JsValue>,
+    options: Option<FetchOptions>
 ) -> Result<web_sys::Request, Error> {
     let mut init = RequestInit::new();
 
@@ -73,6 +74,12 @@ fn prepare_request(
         .headers(headers.as_ref())
         .body(body.as_ref())
         .credentials(RequestCredentials::SameOrigin);
+
+    if let Some(options) = options {
+        if let Some(credentials) = options.credentials {
+            init.credentials(RequestCredentials::from(credentials));
+        }
+    }
 
     web_sys::Request::new_with_str_and_init(url, &init).map_err(Error::js_error)
 }

--- a/src/call.rs
+++ b/src/call.rs
@@ -7,7 +7,7 @@ use http_body::Body;
 use js_sys::{Array, Uint8Array};
 use tonic::body::BoxBody;
 use wasm_bindgen::JsValue;
-use web_sys::{Headers, RequestCredentials, RequestInit};
+use web_sys::{Headers, RequestCredentials, RequestInit, RequestMode, RequestCache, RequestRedirect};
 
 use crate::{fetch::fetch, options::FetchOptions, Error, ResponseBody};
 
@@ -76,9 +76,19 @@ fn prepare_request(
         .credentials(RequestCredentials::SameOrigin);
 
     if let Some(options) = options {
+        if let Some(cache) = options.cache {
+            init.cache(RequestCache::from(cache));
+        }
         if let Some(credentials) = options.credentials {
             init.credentials(RequestCredentials::from(credentials));
         }
+        if let Some(mode) = options.mode {
+            init.mode(RequestMode::from(mode));
+        }
+        if let Some(redirect) = options.redirect {
+            init.redirect(RequestRedirect::from(redirect));
+        }
+        
     }
 
     web_sys::Request::new_with_str_and_init(url, &init).map_err(Error::js_error)

--- a/src/call.rs
+++ b/src/call.rs
@@ -88,7 +88,6 @@ fn prepare_request(
         if let Some(redirect) = options.redirect {
             init.redirect(RequestRedirect::from(redirect));
         }
-        
     }
 
     web_sys::Request::new_with_str_and_init(url, &init).map_err(Error::js_error)


### PR DESCRIPTION
This fixes an issue where the request gets the wrong credentials configuration which is incompatible between the request and the fetch options. 

<img width="1566" alt="image" src="https://github.com/devashishdxt/tonic-web-wasm-client/assets/3721925/80714707-a553-4fb0-ba24-8eaac6bebe85">
