### PR TITLE
refactor use of futures-util crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 base64 = "0.22.0"
 byteorder = "1.5.0"
 bytes = "1.5.0"
-futures-util = "0.3.30"
+futures-util = { version = "0.3.30", default-features = false }
 http = "0.2.11"
 http-body = "0.4.6"
 httparse = "1.8.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,9 @@
 use std::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use futures_util::Future;
 use http::{Request, Response};
 use tonic::body::BoxBody;
 use tower_service::Service;

--- a/src/response_body.rs
+++ b/src/response_body.rs
@@ -1,13 +1,12 @@
 use std::{
     ops::{Deref, DerefMut},
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, Bytes, BytesMut};
-use futures_util::ready;
 use http::{header::HeaderName, HeaderMap, HeaderValue};
 use http_body::Body;
 use httparse::{Status, EMPTY_HEADER};


### PR DESCRIPTION
Disables unused `futures-util` crate's features and uses `Future` and `ready` in standard library.