### PR TITLE
Allow default accept header to be overridden

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -1,8 +1,4 @@
-use http::{
-    header::{ACCEPT, CONTENT_TYPE},
-    response::Builder,
-    HeaderMap, HeaderValue, Request, Response,
-};
+use http::{header::CONTENT_TYPE, response::Builder, HeaderMap, HeaderValue, Request, Response};
 use http_body_util::BodyExt;
 use js_sys::{Array, Uint8Array};
 use tonic::body::Body;
@@ -41,13 +37,10 @@ fn prepare_headers(header_map: &HeaderMap<HeaderValue>) -> Result<Headers, Error
     headers
         .append(CONTENT_TYPE.as_str(), "application/grpc-web+proto")
         .map_err(Error::js_error)?;
-    headers
-        .append(ACCEPT.as_str(), "application/grpc-web+proto")
-        .map_err(Error::js_error)?;
     headers.append("x-grpc-web", "1").map_err(Error::js_error)?;
 
     for (header_name, header_value) in header_map.iter() {
-        if header_name != CONTENT_TYPE && header_name != ACCEPT {
+        if header_name != CONTENT_TYPE {
             headers
                 .append(header_name.as_str(), header_value.to_str()?)
                 .map_err(Error::js_error)?;

--- a/src/call.rs
+++ b/src/call.rs
@@ -36,8 +36,8 @@ pub async fn call(
 }
 
 fn prepare_headers(header_map: &HeaderMap<HeaderValue>) -> Result<Headers, Error> {
+    // Construct default headers.
     let headers = Headers::new().map_err(Error::js_error)?;
-
     headers
         .append(CONTENT_TYPE.as_str(), "application/grpc-web+proto")
         .map_err(Error::js_error)?;
@@ -46,10 +46,12 @@ fn prepare_headers(header_map: &HeaderMap<HeaderValue>) -> Result<Headers, Error
         .map_err(Error::js_error)?;
     headers.append("x-grpc-web", "1").map_err(Error::js_error)?;
 
+    // Apply default headers.
     for (header_name, header_value) in header_map.iter() {
-        if header_name != CONTENT_TYPE && header_name != ACCEPT {
+        // Allow default headers to be overridden except for `content-type`.
+        if header_name != CONTENT_TYPE {
             headers
-                .append(header_name.as_str(), header_value.to_str()?)
+                .set(header_name.as_str(), header_value.to_str()?)
                 .map_err(Error::js_error)?;
         }
     }

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,4 +1,8 @@
-use http::{header::CONTENT_TYPE, response::Builder, HeaderMap, HeaderValue, Request, Response};
+use http::{
+    header::{ACCEPT, CONTENT_TYPE},
+    response::Builder,
+    HeaderMap, HeaderValue, Request, Response,
+};
 use http_body_util::BodyExt;
 use js_sys::{Array, Uint8Array};
 use tonic::body::Body;
@@ -37,10 +41,13 @@ fn prepare_headers(header_map: &HeaderMap<HeaderValue>) -> Result<Headers, Error
     headers
         .append(CONTENT_TYPE.as_str(), "application/grpc-web+proto")
         .map_err(Error::js_error)?;
+    headers
+        .append(ACCEPT.as_str(), "application/grpc-web+proto")
+        .map_err(Error::js_error)?;
     headers.append("x-grpc-web", "1").map_err(Error::js_error)?;
 
     for (header_name, header_value) in header_map.iter() {
-        if header_name != CONTENT_TYPE {
+        if header_name != CONTENT_TYPE && header_name != ACCEPT {
             headers
                 .append(header_name.as_str(), header_value.to_str()?)
                 .map_err(Error::js_error)?;


### PR DESCRIPTION
Closes #73.

Updates the request preparation logic to allow all default headers to be overridden other than `content-type`.